### PR TITLE
Backward compactibility issue

### DIFF
--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,2 +1,3 @@
 Jinja2==2.11.2
 Pygments==2.2.0
+Markupsafe==2.0.1


### PR DESCRIPTION
The soft-unicode method is missing from Markupsafe=>2.0.9. This is supposed to fix that.