### PR TITLE
Add Django 3.1 - 4.2, fix older Django version compatibility, upgrade Jinja2

### DIFF
--- a/requirements-tox.txt
+++ b/requirements-tox.txt
@@ -1,2 +1,2 @@
-Jinja2==2.11.2
+Jinja2>=3.0.0
 Pygments==2.2.0

--- a/src/cdf/__init__.py
+++ b/src/cdf/__init__.py
@@ -1,3 +1,7 @@
+import collections
+import sys
+import typing
+
 import django
 from django.conf import settings
 
@@ -9,5 +13,14 @@ settings.configure(
         }
     },
 )
+
+# Monkey patching needed for newer Python versions and older Django ones:
+if not hasattr(collections, "Mapping"):
+    collections.Mapping = typing.Mapping
+if not hasattr(collections, "Iterator"):
+    collections.Iterator = typing.Iterator
+if not hasattr(collections, "Sequence"):
+    collections.Sequence = typing.Sequence
+sys.modules["collections"] = collections
 
 django.setup()

--- a/src/cdf/config.py
+++ b/src/cdf/config.py
@@ -4,6 +4,11 @@ from cdf.utils import get_major_dot_minor_version
 
 
 DJANGO_VERSIONS = [
+    '4.2',
+    '4.1',
+    '4.0',
+    '3.2',
+    '3.1',
     '3.0',
     '2.2',
     '2.1',

--- a/src/cdf/inspector.py
+++ b/src/cdf/inspector.py
@@ -1,8 +1,8 @@
-import collections
 import inspect
 import json
 import types
 from collections import namedtuple
+from typing import MutableSequence
 
 from django import forms
 from pygments import highlight
@@ -119,7 +119,7 @@ class Property:
         return highlight(code, PythonLexer(), CodeHtmlFormatter(self.instance_class))
 
 
-class KlassItems(collections.MutableSequence):
+class KlassItems(MutableSequence):
 
     def __init__(self):
         self.items = []

--- a/src/cdf/jinja_utils.py
+++ b/src/cdf/jinja_utils.py
@@ -2,7 +2,7 @@ import inspect
 import os
 
 from jinja2 import (
-    contextfunction,
+    pass_context,
     select_autoescape,
     Environment,
     FileSystemLoader,
@@ -18,26 +18,26 @@ template_env = Environment(
 )
 
 
-@contextfunction
+@pass_context
 def get_klass_url(context, klass, version=VERSION):
     return os.path.join(BASE_URL, version, klass.__module__, klass.__name__ + '.html')
 
 
-@contextfunction
+@pass_context
 def get_version_url(context, version):
     if 'this_klass' in context:
         return get_klass_url(context, context['this_klass'], version)
     return os.path.join(BASE_URL, version, 'index.html')
 
 
-@contextfunction
+@pass_context
 def get_klass_docs(context, klass):
     if klass.__doc__ and klass.__doc__.strip():
         return klass.__doc__.strip()
     return ''
 
 
-@contextfunction
+@pass_context
 def get_doc_link(context, klass, version=VERSION):
     base_url = 'https://docs.djangoproject.com/en/{version}/ref/forms/{module}/#{klass}'
     return base_url.format(
@@ -47,7 +47,7 @@ def get_doc_link(context, klass, version=VERSION):
     )
 
 
-@contextfunction
+@pass_context
 def get_src_link(context, klass, version=VERSION):
     src_url = "https://github.com/django/django/blob/stable/{version}.x/django/forms/{module}.py#L{lineno}"
     local_path = inspect.getsourcefile(klass)

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 skipsdist=True
-envlist = dj{18,19,110,111,20,21,22,30},djbuild{18,19,110,111,20,21,22,30}
+envlist = dj{18,19,110,111,20,21,22,30,31,32,40,41,42},djbuild{18,19,110,111,20,21,22,30,31,32,40,41,42}
 
 [testenv]
 deps=
@@ -28,6 +28,21 @@ deps22 =
 
 deps30 =
     django>=3.0,<3.1
+
+deps31 =
+    django>=3.1,<3.2
+
+deps32 =
+    django>=3.2,<4.0
+
+deps40 =
+    django>=4.0,<4.1
+
+deps41 =
+    django>=4.1,<4.2
+
+deps42 =
+    django>=4.2,<4.3
 
 setenv =
     PYTHONPATH = {toxinidir}
@@ -107,6 +122,46 @@ whitelist_externals = make
 commands =
     {[index]commands}
 
+[testenv:dj31]
+deps =
+    {[testenv]deps}
+    {[testenv]deps31}
+whitelist_externals = make
+commands =
+    {[index]commands}
+
+[testenv:dj32]
+deps =
+    {[testenv]deps}
+    {[testenv]deps32}
+whitelist_externals = make
+commands =
+    {[index]commands}
+
+[testenv:dj40]
+deps =
+    {[testenv]deps}
+    {[testenv]deps40}
+whitelist_externals = make
+commands =
+    {[index]commands}
+
+[testenv:dj41]
+deps =
+    {[testenv]deps}
+    {[testenv]deps41}
+whitelist_externals = make
+commands =
+    {[index]commands}
+
+[testenv:dj42]
+deps =
+    {[testenv]deps}
+    {[testenv]deps42}
+whitelist_externals = make
+commands =
+    {[index]commands}
+
 # SITE GENERATION
 
 [testenv:djbuild18]
@@ -177,6 +232,51 @@ deps =
     {[testenv:dj30]deps}
 envdir =
     {toxworkdir}/dj30
+whitelist_externals = make
+commands =
+    {[build]commands}
+
+[testenv:djbuild31]
+deps =
+    {[testenv:dj31]deps}
+envdir =
+    {toxworkdir}/dj31
+whitelist_externals = make
+commands =
+    {[build]commands}
+
+[testenv:djbuild32]
+deps =
+    {[testenv:dj32]deps}
+envdir =
+    {toxworkdir}/dj32
+whitelist_externals = make
+commands =
+    {[build]commands}
+
+[testenv:djbuild40]
+deps =
+    {[testenv:dj40]deps}
+envdir =
+    {toxworkdir}/dj40
+whitelist_externals = make
+commands =
+    {[build]commands}
+
+[testenv:djbuild41]
+deps =
+    {[testenv:dj41]deps}
+envdir =
+    {toxworkdir}/dj41
+whitelist_externals = make
+commands =
+    {[build]commands}
+
+[testenv:djbuild42]
+deps =
+    {[testenv:dj42]deps}
+envdir =
+    {toxworkdir}/dj42
 whitelist_externals = make
 commands =
     {[build]commands}


### PR DESCRIPTION
I added all newer Django versions and monkey patched `collections` so that the oldest ones would build. I also upgraded Jinja2  because older versions don't work with newer Markupsafe. Then I discovered someone else had already made a PR with newer Django versions. But in mine, we don't need to throw away the oldest ones. :-)